### PR TITLE
Changed js open to standard anchor (link)

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -27,7 +27,7 @@ chrome.extension.sendMessage({}, function(response) {
 							latestDlUrl = dlUrl;
 						}
 
-						jQuery('.get-extension-button .button-purchase', this).append('<button type="button" class="ui-button ui-button-blue-huge" title="'+ directDlMsg +'" onclick="window.open(\''+ dlUrl +'\', \'_blank\');">'+ directDlMsg +'</button>');
+						jQuery('.get-extension-button .button-purchase', this).append('<a href="'+dlUrl+'" target="_blank"><button type="button" class="ui-button ui-button-blue-huge" title="'+ directDlMsg +'">'+ directDlMsg +'</button></a>');
 					}
 				}				
 			});


### PR DESCRIPTION
Sometimes need to copy the url to install it on the server instead of download to local place.
Thus you can copy the direct link and install it on the server directly.